### PR TITLE
Global wildcard's configuration prefetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,9 @@
 Changes
 ~~~~~~~
 
-.. Future (?)
-.. ----------
-.. -
+latest  (to release)
+--------------------
+- allow wildcards in prefetch
 
 1.0.0b4 (2019-07-14)
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -93,11 +93,6 @@ autoshare applied to all repos of some organizations::
                 - acsone
             private: True
 
-.. note::
-
-   In this configuration, ``git-autoshare-prefetch`` without arguments
-   will not fetch any wildcard repo. This could be improved in the future
-   to refetch repos that are already present in cache.
 
 git autoshare-clone command
 ---------------------------

--- a/git_autoshare/core.py
+++ b/git_autoshare/core.py
@@ -89,15 +89,47 @@ def find_autoshare_repository(args):
     return -1, None
 
 
+def _get_all_declared_repos(host):
+    """ Get all declared repos from config for a single host
+    """
+    return set(config()[host].keys()).difference(["*"])
+
+
+def _get_cached_and_undeclared_repositories(host):
+    """ Returns only cached repositories and undeclared in configuration
+    """
+    host_dir = os.path.join(cache_dir(), host)
+    # If folder doesn't exist, autoshare-clone or submodules were not used yet
+    if os.path.isdir(host_dir):
+        cached_repos = os.listdir(host_dir)  # From cache only
+        declared_repos = _get_all_declared_repos(host)  # From repos only
+        # Return the difference
+        return set(cached_repos).difference(declared_repos)
+    return []
+
+
+def find_wildcarded_repositories(host, orgs, private):
+    """ Find undeclared repositories from a single wildcard configuration
+    """
+    for repo in _get_cached_and_undeclared_repositories(host):
+        print("Found a cached repository '{}'".format(repo))
+        orgs_path = os.path.join(cache_dir(), host, repo, "refs", "git-autoshare")
+        # If a cached org's folder doesn't exist, clone has not been called yet
+        # We don't process it
+        # And lowercase is used to avoid differences by false negative
+        if os.path.exists(orgs_path):
+            existing_orgs = [o.lower() for o in os.listdir(orgs_path)]
+            # But we keep the original org value for further process
+            valid_orgs = [org for org in orgs if org.lower() in existing_orgs]
+            if valid_orgs:
+                print("Processing '{}' for orgs {}".format(repo, valid_orgs))
+                yield AutoshareRepository(host, valid_orgs, repo, private)
+
+
 def autoshare_repositories():
     hosts = config()
     for host, repos in hosts.items():
         for repo, repo_data in repos.items():
-            if repo == "*":
-                # TODO list cache directory? in which case the
-                # TODO orgs to fetch must be take from refs/git-autoshare/*
-                # TODO because a repo may not exist in all remotes
-                continue
             if isinstance(repo_data, dict):
                 orgs = repo_data.get("orgs", [])
                 private = repo_data.get("private", False)
@@ -105,7 +137,17 @@ def autoshare_repositories():
                 orgs = repo_data
                 private = False
 
-            yield AutoshareRepository(host, orgs, repo, private)
+            if repo == "*":
+                print(
+                    "Global prefetch started for host {} and orgs {}...".format(
+                        host, orgs
+                    )
+                )
+                for ar in find_wildcarded_repositories(host, orgs, private):
+                    yield ar
+            else:
+                yield AutoshareRepository(host, orgs, repo, private)
+
 
 class AutoshareRepository:
     def __init__(self, host, orgs, repo, private):
@@ -140,8 +182,18 @@ class AutoshareRepository:
                 "refs/heads/*:refs/git-autoshare/{org}/heads/*".format(org=org)
             )
             try:
+                print("Prefetching {}/{}/{}".format(self.host, org, self.repo))
                 subprocess.check_call(fetch_cmd, cwd=self.repo_dir)
             except Exception:
                 if new_repo_dir:
                     shutil.rmtree(self.repo_dir)
                 raise
+
+    def __eq__(self, other):
+        if isinstance(other, AutoshareRepository):
+            return (
+                self.repo_dir == other.repo_dir
+                and self.orgs == other.orgs
+                and self.private == other.private
+            )
+        return False

--- a/tests/test_git_autoshare.py
+++ b/tests/test_git_autoshare.py
@@ -254,12 +254,10 @@ def test_find_autoshare_repository(config):
     assert ar
     assert index == 2
     assert ar.host == "github.com"
-    assert ar.org == "acsone"
+    assert "acsone" in ar.orgs
     assert not ar.private
     assert ar.repo == "git-aggregator"
-    assert ar.repo_dir == os.path.join(
-        str(config.cache_dir), "github.com/git-aggregator"
-    )
+    assert ar.repo_dir == os.path.join(str(config.cache_dir), ar.host, ar.repo)
 
     cmd = [git_bin(), "clone", "https://github.com/acsone/git-autoshare.git"]
     index, ar = find_autoshare_repository(cmd)


### PR DESCRIPTION
Add the ability to prefetch wildcards configurations.

In case of full wildcard configuration (to force all repositories to be cached), the original code was unable to do that. As read in the code :
``` python
def autoshare_repositories():
    hosts = config()
    for host, repos in hosts.items():
        for repo, repo_data in repos.items():
            if repo == "*":
                # TODO list cache directory? in which case the
                # TODO orgs to fetch must be take from refs/git-autoshare/*
                # TODO because a repo may not exist in all remotes
...
```
I solved this issue by parsing gradually the cache for organisations in already cached repositories (it does not make sense otherwize), and also by filtering declared organisation by cached ones. Now prefetch is able to process any configuration, including wildcards in multiple hosts.

Any formal or subjective returns would be much appreciated.