### PR TITLE
Package suggested git script with Python package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,19 +30,8 @@ To upgrade git-autoshare at any time::
 
     $ pipx upgrade git-autoshare
 
-If you want ``git autoshare-clone`` to be invoked transparently in place of ``git clone``,
-create the following bash script, name it ``git``, and place it in your ``PATH`` before ``/usr/bin/git``:
-
-  .. code:: bash
-
-    #!/bin/bash
-    if [ "$1" == "clone" ]
-    then
-        shift
-        /usr/bin/git autoshare-clone "$@"
-    else
-        /usr/bin/git "$@"
-    fi
+This will also install a simple script to transparently replace your calls to ``git clone`` with calls to
+``git autoshare-clone``. To enable it, export `GIT_AUTOSHARE=1` in your shell.
 
 Usage
 ~~~~~

--- a/scripts/git
+++ b/scripts/git
@@ -1,0 +1,8 @@
+#!/bin/bash
+if [[ "$GIT_AUTOSHARE" == "1" && "$1" == "clone" ]]
+then
+    shift
+    /usr/bin/git autoshare-clone "$@"
+else
+    /usr/bin/git "$@"
+fi

--- a/setup.py
+++ b/setup.py
@@ -32,4 +32,5 @@ setuptools.setup(
             "git-autoshare-submodule-add=git_autoshare.submodule:add",
         ]
     },
+    scripts=["scripts/git"]
 )


### PR DESCRIPTION
As suggested in https://github.com/acsone/git-aggregator/pull/55

@sbidoul @Yajo this solves the problem by using a pure Bash script. However, I still haven't found a way of making it optional on install... Any ideas?

Some notes on what was already explored:

1. A Python script to replace the `git` command is not viable due to Python load times.
2. `setuptools` allows you to define optional commands to be insatalled, but AFAIK only through `entry_points`, which is only meant for Python modules.
3. I tried packaging a Python script that would only override `git clone` (`git-clone`) as that would not introduce more delays that `autoshare` itself and it would only affect the `clone` operation. However, even when I have `git-clone` in the path, `git clone` still redirects to the normal command. I guess it is one of those subcommands that can't be replaced...

@Tecnativa 
TT32042