### PR TITLE
[IMP] Add support for git clone --recurse-submodule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,19 +4,19 @@ repos:
   hooks:
   - id: black
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
   - id: check-yaml
   - id: debug-statements
 - repo: https://github.com/PyCQA/flake8
-  rev: 5.0.4
+  rev: 7.3.0
   hooks:
   - id: flake8
-    additional_dependencies: ["flake8-bugbear==21.4.3"]
+    additional_dependencies: ["flake8-bugbear==25.11.29"]
 - repo: https://github.com/asottile/pyupgrade
-  rev: v3.1.0
+  rev: v3.21.2
   hooks:
   - id: pyupgrade
 - repo: https://github.com/asottile/seed-isort-config
@@ -24,6 +24,6 @@ repos:
   hooks:
   - id: seed-isort-config
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 8.0.1
   hooks:
   - id: isort

--- a/git_autoshare/clone.py
+++ b/git_autoshare/clone.py
@@ -4,10 +4,13 @@
 
 import subprocess
 import sys
+import time
 
 from .core import enable_gevent, find_autoshare_repository, git_bin
 from .submodule import iter_submodules
 from .submodule import update as submodule_update
+
+WATCHER_INTERVAL = 30  # seconds between "still running" reports
 
 
 def main():
@@ -42,23 +45,79 @@ def _init_submodules(target, quiet, parallel=None):
         return 0
     if parallel:
         if not enable_gevent():
-            print("git-autoshare: gevent not available, falling back to sequential submodule update")
+            print(
+                "git-autoshare: gevent not available, "
+                "falling back to sequential submodule update"
+            )
             parallel = False
     elif parallel is None:
         parallel = enable_gevent()
     if parallel:
-        from gevent.pool import Pool
-
-        pool = Pool(size=min(len(submodules), 10))
-        results = pool.map(
-            lambda pu: submodule_update(target, pu[0], pu[1], quiet), submodules
-        )
-        return next((r for r in results if r != 0), 0)
+        return _init_submodules_parallel(target, quiet, submodules)
     for path, url in submodules:
         r = submodule_update(target, path, url, quiet)
         if r != 0:
             return r
     return 0
+
+
+def _init_submodules_parallel(target, quiet, submodules):
+    """Run submodule updates concurrently via gevent.
+
+    Logs `start`/`done`/`FAIL` markers per submodule and a periodic
+    `still running` report so the user can tell which submodule is the
+    long pole when many clones are in flight.
+    """
+    import gevent
+    from gevent.pool import Pool
+
+    total = len(submodules)
+    in_flight = {}  # path -> start time (monotonic)
+    completed = 0
+
+    print(f"git-autoshare: updating {total} submodules in parallel")
+
+    def run(idx, path, url):
+        nonlocal completed
+        in_flight[path] = time.monotonic()
+        print("[{}/{}] start  {}".format(idx + 1, total, path), flush=True)
+        r = submodule_update(target, path, url, quiet)
+        elapsed = time.monotonic() - in_flight.pop(path)
+        completed += 1
+        tag = "done " if r == 0 else "FAIL "
+        print(
+            "[{}/{}] {} {} ({:.1f}s)".format(completed, total, tag, path, elapsed),
+            flush=True,
+        )
+        return r
+
+    def watch():
+        while True:
+            gevent.sleep(WATCHER_INTERVAL)
+            if not in_flight:
+                return
+            now = time.monotonic()
+            lines = [
+                "  {} ({:.0f}s)".format(p, now - t)
+                for p, t in sorted(in_flight.items())
+            ]
+            print(
+                "git-autoshare: still running ({}/{}):\n{}".format(
+                    len(in_flight), total, "\n".join(lines)
+                ),
+                flush=True,
+            )
+
+    watcher = gevent.spawn(watch)
+    pool = Pool(size=min(total, 10))
+    try:
+        results = pool.map(
+            lambda i_pu: run(i_pu[0], i_pu[1][0], i_pu[1][1]),
+            list(enumerate(submodules)),
+        )
+    finally:
+        watcher.kill()
+    return next((r for r in results if r != 0), 0)
 
 
 def get_clone_target_dir_from_args(args):

--- a/git_autoshare/clone.py
+++ b/git_autoshare/clone.py
@@ -6,15 +6,21 @@ import subprocess
 import sys
 
 from .core import find_autoshare_repository, git_bin
+from .submodule import iter_submodules
+from .submodule import update as submodule_update
 
 
 def main():
-    cmd = [git_bin(), "clone"] + sys.argv[1:]
+    args = sys.argv[1:]
+    recurse = "--recurse-submodules" in args or "--recursive" in args
+    args = [a for a in args if a not in ("--recurse-submodules", "--recursive")]
+
+    cmd = [git_bin(), "clone"] + args
     skip = any(
         c in cmd for c in ["--reference", "--reference-if-able", "-s", "--share"]
     )
+    quiet = "-q" in cmd or "--quiet" in cmd
     if not skip:
-        quiet = "-q" in cmd or "--quiet" in cmd
         index, ar = find_autoshare_repository(cmd)
         if ar:
             ar.prefetch(quiet)
@@ -22,4 +28,28 @@ def main():
                 print("git-autoshare clone added --reference", ar.repo_dir)
             cmd = cmd[:index] + ["--reference", ar.repo_dir] + cmd[index:]
     r = subprocess.call(cmd)
-    sys.exit(r)
+    if r != 0 or not recurse:
+        sys.exit(r)
+
+    target, _explicit_target = get_clone_target_dir_from_args(args)
+    sys.exit(_init_submodules(target, quiet))
+
+
+def _init_submodules(target, quiet):
+    for path, url in iter_submodules(target):
+        r = submodule_update(target, path, url, quiet)
+        if r != 0:
+            return r
+    return 0
+
+
+def get_clone_target_dir_from_args(args):
+    """Returns the target directory of the clone, and whether it was explicitly"""
+    positionals = [a for a in args if not a.startswith("-")]
+    # Check if we provided an explicity destination
+    if len(positionals) >= 2:
+        return positionals[-1], True
+    # Extract from the repo URL
+    name = positionals[0].rstrip("/").rsplit("/", 1)[-1]
+    dest = name[:-4] if name.endswith(".git") else name
+    return dest, False

--- a/git_autoshare/clone.py
+++ b/git_autoshare/clone.py
@@ -5,7 +5,7 @@
 import subprocess
 import sys
 
-from .core import find_autoshare_repository, git_bin
+from .core import enable_gevent, find_autoshare_repository, git_bin
 from .submodule import iter_submodules
 from .submodule import update as submodule_update
 
@@ -35,8 +35,26 @@ def main():
     sys.exit(_init_submodules(target, quiet))
 
 
-def _init_submodules(target, quiet):
-    for path, url in iter_submodules(target):
+def _init_submodules(target, quiet, parallel=None):
+    """Use gevent to run init in parallel or fallback to regular loop"""
+    submodules = list(iter_submodules(target))
+    if not submodules:
+        return 0
+    if parallel:
+        if not enable_gevent():
+            print("git-autoshare: gevent not available, falling back to sequential submodule update")
+            parallel = False
+    elif parallel is None:
+        parallel = enable_gevent()
+    if parallel:
+        from gevent.pool import Pool
+
+        pool = Pool(size=min(len(submodules), 10))
+        results = pool.map(
+            lambda pu: submodule_update(target, pu[0], pu[1], quiet), submodules
+        )
+        return next((r for r in results if r != 0), 0)
+    for path, url in submodules:
         r = submodule_update(target, path, url, quiet)
         if r != 0:
             return r

--- a/git_autoshare/core.py
+++ b/git_autoshare/core.py
@@ -171,7 +171,9 @@ class AutoshareRepository:
         self.private = private
         self.repo_dir = os.path.join(cache_dir(), self.host, self.repo)
 
-    def prefetch(self, quiet):
+    def prefetch(self, quiet, orgs=None):
+        if orgs is None:
+            orgs = self.orgs
         new_repo_dir = False
         if not os.path.exists(os.path.join(self.repo_dir, "objects")):
             new_repo_dir = True
@@ -179,7 +181,7 @@ class AutoshareRepository:
                 os.makedirs(self.repo_dir)
             subprocess.check_call([git_bin(), "init", "--bare"], cwd=self.repo_dir)
 
-        for org in self.orgs:
+        for org in orgs:
             if self.private:
                 repo_url = "ssh://git@{host}/{org}/{repo}.git".format(
                     host=self.host, org=org, repo=self.repo
@@ -202,6 +204,30 @@ class AutoshareRepository:
                 if new_repo_dir:
                     shutil.rmtree(self.repo_dir)
                 raise
+
+    def has_org_refs(self, org):
+        """True if the cache already holds at least one ref under
+        refs/git-autoshare/<org>/heads/."""
+        result = subprocess.run(
+            [
+                git_bin(),
+                "for-each-ref",
+                "--format=%(refname)",
+                "refs/git-autoshare/{}/heads/".format(org),
+            ],
+            cwd=self.repo_dir,
+            capture_output=True,
+        )
+        return bool(result.stdout.strip())
+
+    def ensure_cache(self, quiet):
+        """Make sure the cache exists and contains refs for every configured org."""
+        if not os.path.exists(os.path.join(self.repo_dir, "objects")):
+            self.prefetch(quiet)
+            return
+        missing = [org for org in self.orgs if not self.has_org_refs(org)]
+        if missing:
+            self.prefetch(quiet, orgs=missing)
 
     def __hash__(self):
         return hash(self.repo_dir + str(self.private) + str(self.orgs))

--- a/git_autoshare/core.py
+++ b/git_autoshare/core.py
@@ -13,6 +13,24 @@ from . import giturlparse
 
 APP_NAME = "git-autoshare"
 
+_gevent_enabled = None
+
+
+def enable_gevent():
+    """Detect gevent and monkey-patch subprocess if available. Idempotent.
+    Returns True if gevent is available and ready to use, False otherwise."""
+    global _gevent_enabled
+    if _gevent_enabled is not None:
+        return _gevent_enabled
+    try:
+        from gevent import monkey
+    except ImportError:
+        _gevent_enabled = False
+        return False
+    monkey.patch_subprocess()
+    _gevent_enabled = True
+    return True
+
 
 def cache_dir():
     return os.environ.get("GIT_AUTOSHARE_CACHE_DIR") or appdirs.user_cache_dir(APP_NAME)

--- a/git_autoshare/submodule.py
+++ b/git_autoshare/submodule.py
@@ -40,8 +40,7 @@ def update(repo_dir, path, url, quiet):
         cmd.append("--quiet")
     _, ar = find_autoshare_repository([url])
     if ar:
-        if not (Path(ar.repo_dir) / "objects").exists():
-            ar.prefetch(quiet)
+        ar.ensure_cache(quiet)
         cmd += ["--reference", ar.repo_dir]
     cmd.append(path)
     return subprocess.call(cmd, cwd=repo_dir)
@@ -54,8 +53,7 @@ def add():
         quiet = "-q" in cmd or "--quiet" in cmd
         index, ar = find_autoshare_repository(cmd)
         if ar:
-            if not Path(ar.repo_dir).exists():
-                ar.prefetch(quiet)
+            ar.ensure_cache(quiet)
             if not quiet:
                 print("git-autoshare submodule-add added --reference", ar.repo_dir)
             cmd = cmd[:index] + ["--reference", ar.repo_dir] + cmd[index:]

--- a/git_autoshare/submodule.py
+++ b/git_autoshare/submodule.py
@@ -3,11 +3,48 @@
 # License GPLv3 (http://www.gnu.org/licenses/gpl-3.0-standalone.html)
 
 
-import os
 import subprocess
 import sys
+from pathlib import Path
 
 from .core import find_autoshare_repository, git_bin
+
+
+def iter_submodules(path=None):
+    """Yield (path, url) for each submodule declared in .gitmodules file"""
+    path = Path(path) if path else Path()
+    gitmodules = path if path.is_file() else path / ".gitmodules"
+    if not gitmodules.exists():
+        return
+    out = subprocess.check_output(
+        [git_bin(), "config", "-f", str(gitmodules), "-l"]
+    ).decode()
+    submodules = {}
+    for line in out.splitlines():
+        key, _, value = line.partition("=")
+        if not key.startswith("submodule."):
+            continue
+        name, _, field = key[len("submodule.") :].rpartition(".")
+        if field in ("path", "url"):
+            submodules.setdefault(name, {})[field] = value
+    for sub in submodules.values():
+        path, url = sub.get("path"), sub.get("url")
+        if path and url:
+            yield path, url
+
+
+def update(repo_dir, path, url, quiet):
+    """git submodule update --init <path> --reference <cache>"""
+    cmd = [git_bin(), "submodule", "update", "--init"]
+    if quiet:
+        cmd.append("--quiet")
+    _, ar = find_autoshare_repository([url])
+    if ar:
+        if not (Path(ar.repo_dir) / "objects").exists():
+            ar.prefetch(quiet)
+        cmd += ["--reference", ar.repo_dir]
+    cmd.append(path)
+    return subprocess.call(cmd, cwd=repo_dir)
 
 
 def add():
@@ -17,7 +54,7 @@ def add():
         quiet = "-q" in cmd or "--quiet" in cmd
         index, ar = find_autoshare_repository(cmd)
         if ar:
-            if not os.path.exists(ar.repo_dir):
+            if not Path(ar.repo_dir).exists():
                 ar.prefetch(quiet)
             if not quiet:
                 print("git-autoshare submodule-add added --reference", ar.repo_dir)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setuptools.setup(
     url="http://github.com/acsone/git-autoshare",
     packages=["git_autoshare"],
     install_requires=["appdirs", "click", "pyyaml"],
+    extras_require={"parallel": ["gevent"]},
     python_requires=">=3.6",
     setup_requires=["setuptools-scm"],
     entry_points={


### PR DESCRIPTION
I discovered that this git extension does not automatically work for submodules.  
I see that some people have made their own tools for that, but I think it's worth centralizing our efforts in the extension directly.

If gevent is installed, it will proceed in parallel for all submodules.

Another issue was that, once a repository is in the cache, it does not consider newly added orgs.
Now, if the repository is already in the cache, it will check the orgs and make sure they are all pulled correctly.